### PR TITLE
Android cmake additions, enable System::demangleTypeName() on gcc

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -429,10 +429,10 @@ include_directories(
     ${CINDER_INC_DIR} 
     ${CINDER_INC_DIR}/freetype
     ${CINDER_INC_DIR}/jsoncpp
-	${CINDER_INC_DIR}/tinyexr
+    ${CINDER_INC_DIR}/tinyexr
     ${CINDER_SRC_DIR}/linebreak
     ${CINDER_SRC_DIR}/libtess2
-	${BOOST_INC_DIR}
+    ${BOOST_INC_DIR}
 )
 
 # Arch flags
@@ -587,7 +587,7 @@ set( CINDER_CXX_SRC_FILES
     ${CINDER_SRC_DIR}/cinder/ImageSourceFileRadiance.cpp
     ${CINDER_SRC_DIR}/cinder/ImageSourceFileStbImage.cpp
     ${CINDER_SRC_DIR}/cinder/ImageTargetFileStbImage.cpp
-	${CINDER_SRC_DIR}/cinder/ImageFileTinyExr.cpp
+    ${CINDER_SRC_DIR}/cinder/ImageFileTinyExr.cpp
     ${CINDER_SRC_DIR}/cinder/Json.cpp
     ${CINDER_SRC_DIR}/cinder/Log.cpp
     ${CINDER_SRC_DIR}/cinder/Matrix.cpp
@@ -665,9 +665,9 @@ set( CINDER_CXX_SRC_FILES
     ${CINDER_SRC_DIR}/freetype/cid/type1cid.c
     ${CINDER_SRC_DIR}/freetype/bdf/bdflib.c
 
-	${CINDER_SRC_DIR}/tinyexr/tinyexr.cc
+    ${CINDER_SRC_DIR}/tinyexr/tinyexr.cc
 
-	${CINDER_SRC_DIR}/../blocks/MotionManager/src/cinder/MotionManager.cpp
+    ${CINDER_SRC_DIR}/../blocks/MotionManager/src/cinder/MotionManager.cpp
     ${CINDER_SRC_DIR}/../blocks/MotionManager/src/cinder/MotionImplAndroid.cpp
 )
 

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -423,14 +423,16 @@ project( cinder_android )
 
 # Output path
 set( LIBRARY_OUTPUT_PATH ${CINDER_DIR}/lib/android/${NDK_PLATFORM_OUT}/${NKD_ARCH_OUT} )
+set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH} )
 
 include_directories( 
     ${CINDER_INC_DIR} 
     ${CINDER_INC_DIR}/freetype
-    ${CINDER_INC_DIR}/jsoncpp 
-    ${CINDER_SRC_DIR}/linebreak 
-    ${CINDER_SRC_DIR}/libtess2 
-    ${BOOST_INC_DIR} 
+    ${CINDER_INC_DIR}/jsoncpp
+	${CINDER_INC_DIR}/tinyexr
+    ${CINDER_SRC_DIR}/linebreak
+    ${CINDER_SRC_DIR}/libtess2
+	${BOOST_INC_DIR}
 )
 
 # Arch flags
@@ -585,6 +587,7 @@ set( CINDER_CXX_SRC_FILES
     ${CINDER_SRC_DIR}/cinder/ImageSourceFileRadiance.cpp
     ${CINDER_SRC_DIR}/cinder/ImageSourceFileStbImage.cpp
     ${CINDER_SRC_DIR}/cinder/ImageTargetFileStbImage.cpp
+	${CINDER_SRC_DIR}/cinder/ImageFileTinyExr.cpp
     ${CINDER_SRC_DIR}/cinder/Json.cpp
     ${CINDER_SRC_DIR}/cinder/Log.cpp
     ${CINDER_SRC_DIR}/cinder/Matrix.cpp
@@ -660,9 +663,11 @@ set( CINDER_CXX_SRC_FILES
     ${CINDER_SRC_DIR}/freetype/pshinter/pshinter.c
     ${CINDER_SRC_DIR}/freetype/psnames/psnames.c
     ${CINDER_SRC_DIR}/freetype/cid/type1cid.c
-    ${CINDER_SRC_DIR}/freetype/bdf/bdflib.c 
+    ${CINDER_SRC_DIR}/freetype/bdf/bdflib.c
 
-    ${CINDER_SRC_DIR}/../blocks/MotionManager/src/cinder/MotionManager.cpp
+	${CINDER_SRC_DIR}/tinyexr/tinyexr.cc
+
+	${CINDER_SRC_DIR}/../blocks/MotionManager/src/cinder/MotionManager.cpp
     ${CINDER_SRC_DIR}/../blocks/MotionManager/src/cinder/MotionImplAndroid.cpp
 )
 

--- a/src/cinder/System.cpp
+++ b/src/cinder/System.cpp
@@ -42,7 +42,6 @@
 	#import <net/ethernet.h>
 	#import <net/if_dl.h>
 	#include <sys/sysctl.h>
-	#include <cxxabi.h>
 #elif defined( CINDER_MSW )
 	#include <windows.h>
 	#include <windowsx.h>
@@ -62,7 +61,12 @@
 	using namespace cinder::winrt;
 #endif
 
+#if defined( __clang__ ) || defined( __GNUC__ )
+	#include <cxxabi.h>
+#endif
+
 #include <string>
+
 using namespace std;
 
 namespace cinder {
@@ -622,14 +626,13 @@ int32_t System::getMaxMultiTouchPoints()
 
 string System::demangleTypeName( const char *mangledName )
 {
-#if defined( CINDER_COCOA )
+#if defined( CINDER_MSW )
+	return mangledName;
+#else
 	int status = 0;
-
-	std::unique_ptr<char, void(*)(void *)> result { abi::__cxa_demangle( mangledName, NULL, NULL, &status ), std::free };
+	std::unique_ptr<char, void(*)(void *)> result { abi::__cxa_demangle( mangledName, NULL, NULL, &status ), free };
 
 	return ( status == 0 ) ? result.get() : mangledName;
-#else
-	return mangledName;
 #endif
 }
 


### PR DESCRIPTION
These are a few additions I had for my current android project.

For cmake:

* building new TinyEXR image file decider / encoder
* added  `CMAKE_ARCHIVE_OUTPUT_DIRECTORY` directive which allows you to build from within CLion and the output .a ends up in the appropriate cinder/lib/android destination

Enabling `System::demangleTypeName()` was straightforward, I use it along with the `CI_LOG_EXCEPTION()` macro throughout our app.