### PR TITLE
CI_ASSERT() routes directly to android logger for now.

### DIFF
--- a/src/cinder/CinderAssert.cpp
+++ b/src/cinder/CinderAssert.cpp
@@ -27,6 +27,11 @@
 
 #include <iostream>
 
+#if defined( CINDER_ANDROID )
+#include <android/log.h>
+#include <sstream>
+#endif
+
 namespace cinder { namespace detail {
 
 void assertionFailedBreak( char const *expr, char const *function, char const *file, long line )
@@ -43,12 +48,15 @@ void assertionFailedMessageBreak( char const *expr, char const *msg, char const 
 
 void assertionFailedMessageAbort( char const *expr, char const *msg, char const *function, char const *file, long line )
 {
-	std::cerr << "*** Assertion Failed *** | expression: ( " << expr << " ), location: " << file << "[" << line << "], " << function << "\n\tmessage: " << msg << std::endl;
 #if defined( CINDER_ANDROID )
+	std::stringstream ss;
+	ss << "*** Assertion Failed *** | expression: ( " << expr << " ), location: " << file << "[" << line << "], " << function << "\n\tmessage: " << msg << std::endl;
+	__android_log_print( ANDROID_LOG_FATAL, "cinder", ss.str().c_str() );
 	std::terminate();
-#else	
+#else
+	std::cerr << "*** Assertion Failed *** | expression: ( " << expr << " ), location: " << file << "[" << line << "], " << function << "\n\tmessage: " << msg << std::endl;
 	std::abort();
-#endif	
+#endif
 }
 
 } } // namespace cinder::detail


### PR DESCRIPTION
It would be nice to go through `ci::log`, but that would cause weird info related to CinderAssert.cpp instead of where the assertion failed. So for now, use android logging directly instead of `std::err`, which goes nowhere.