### PR TITLE
Include stb_image implementations statically

### DIFF
--- a/src/cinder/ImageSourceFileStbImage.cpp
+++ b/src/cinder/ImageSourceFileStbImage.cpp
@@ -25,6 +25,7 @@
 #define STBI_NO_PIC
 #define STBI_NO_PNM
 #define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_STATIC
 #include "stb/stb_image.h"
 
 namespace cinder {

--- a/src/cinder/ImageTargetFileStbImage.cpp
+++ b/src/cinder/ImageTargetFileStbImage.cpp
@@ -24,6 +24,7 @@
 #include "cinder/ImageTargetFileStbImage.h"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
+#define STB_IMAGE_WRITE_STATIC
 #include "stb/stb_image_write.h"
 
 namespace cinder {


### PR DESCRIPTION
This allows libraries that also include implementations of `stb_image` and `stb_image_write` to be linked with Cinder without causing multiple definition errors.

The android build includes `ImageTargetFileStbImage` et al, which is a problem for nanovg. It's a bit of a bummer to have everything implemented twice, but this was the best solution I could think of that doesn't ask the user to provide an implementation.. Limit of the stb single header style I suppose?