### PR TITLE
Android ci::log sync

### DIFF
--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -182,6 +182,9 @@ protected:
 #elif defined( CINDER_MSW )
 	class ImplEventLog;
 	std::unique_ptr<ImplEventLog> mImpl;
+#elif defined( CINDER_ANDROID )
+	class ImplLogCat;
+	std::unique_ptr<ImplLogCat> mImpl;
 #endif
 };
 

--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -27,6 +27,7 @@
 #include "cinder/Filesystem.h"
 #include "cinder/CurrentFunction.h"
 #include "cinder/CinderAssert.h"
+#include "cinder/Noncopyable.h"
 #include "cinder/System.h"
 
 #include <sstream>
@@ -34,67 +35,6 @@
 #include <vector>
 #include <memory>
 #include <mutex>
-
-#if defined( CINDER_MSW ) && ( _MSC_VER < 1800 )
-	#define CINDER_NO_VARIADIC_TEMPLATES
-	#include <boost/preprocessor/repetition.hpp>
-	#include <boost/preprocessor/control/if.hpp>
-#endif
-
-#if defined( CINDER_ANDROID )
- 	#include <sstream>
-#endif 
-
-#define CINDER_LOG_STREAM( level, stream ) ::cinder::log::Entry( level, ::cinder::log::Location( CINDER_CURRENT_FUNCTION, __FILE__, __LINE__ ) ) << stream
-
-// CI_MAX_LOG_LEVEL is designed so that if you set it to 0, nothing logs, 1 only fatal, 2 fatal + error, etc...
-
-#if ! defined( CI_MAX_LOG_LEVEL )
-	#if ! defined( NDEBUG )
-		#define CI_MAX_LOG_LEVEL 5	// debug mode default is LEVEL_VERBOSE
-	#else
-		#define CI_MAX_LOG_LEVEL 4	// release mode default is LEVEL_INFO
-	#endif
-#endif
-
-#if( CI_MAX_LOG_LEVEL >= 5 )
-	#define CI_LOG_V( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_VERBOSE, stream )
-#else
-	#define CI_LOG_V( stream )	((void)0)
-#endif
-
-#if( CI_MAX_LOG_LEVEL >= 4 )
-	#define CI_LOG_I( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_INFO, stream )
-#else
-	#define CI_LOG_I( stream )	((void)0)
-#endif
-
-// Use the same level as INFO for now
-#if defined( CINDER_ANDROID )
-	#if( CI_MAX_LOG_LEVEL >= 4 )
-		#define CI_LOG_D( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_DEBUG, stream )
-	#else
-		#define CI_LOG_D( stream )	((void)0)
-	#endif
-#endif
-
-#if( CI_MAX_LOG_LEVEL >= 3 )
-	#define CI_LOG_W( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_WARNING, stream )
-#else
-	#define CI_LOG_W( stream )	((void)0)
-#endif
-
-#if( CI_MAX_LOG_LEVEL >= 2 )
-	#define CI_LOG_E( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_ERROR, stream )
-#else
-	#define CI_LOG_E( stream )	((void)0)
-#endif
-
-#if( CI_MAX_LOG_LEVEL >= 1 )
-	#define CI_LOG_F( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_FATAL, stream )
-#else
-	#define CI_LOG_F( stream )	((void)0)
-#endif
 
 namespace cinder { namespace log {
 
@@ -106,12 +46,6 @@ typedef enum {
 	LEVEL_ERROR,
 	LEVEL_FATAL
 } Level;
-
-typedef enum {
-	OUTPUT_DEFAULT,
-	OUTPUT_CONSOLE,
-	OUTPUT_FILE
-} Output;
 
 struct Location {
 	Location() {}
@@ -140,44 +74,49 @@ struct Metadata {
 extern std::ostream& operator<<( std::ostream &os, const Location &rhs );
 extern std::ostream& operator<<( std::ostream &lhs, const Level &rhs );
 
-class Logger {
+//! Logger is the base class all logging objects are derived from.
+//!
+//! \see LoggerConsole, LoggerFile, LoggerFileRotating
+class Logger : private Noncopyable {
   public:
 	virtual ~Logger()	{}
 
 	virtual void write( const Metadata &meta, const std::string &text ) = 0;
 
-	void 	setTimestampEnabled( bool enable = true )	{ mTimeStampEnabled = enable; }
-	bool 	isTimestampEnabled() const					{ return mTimeStampEnabled; }
-	Output 	getOutput() const 							{ return mOutput; }
-
+	void setTimestampEnabled( bool enable = true )	{ mTimeStampEnabled = enable; }
+	bool isTimestampEnabled() const					{ return mTimeStampEnabled; }
+	
   protected:
-	Logger( Output output = OUTPUT_DEFAULT ) : mTimeStampEnabled( false ), mOutput( output ) {}
+	Logger() : mTimeStampEnabled( false ) {}
 
 	void writeDefault( std::ostream &stream, const Metadata &meta, const std::string &text );
 
   private:
-	bool 	mTimeStampEnabled;
-	Output 	mOutput;
+	bool mTimeStampEnabled;
 };
+	
+typedef std::shared_ptr<Logger>	LoggerRef;
 
+//! LoggerConsole prints log messages in the application console window.
 class LoggerConsole : public Logger {
   public:
 	void write( const Metadata &meta, const std::string &text ) override;
 };
 
+//! \brief LoggerFile will write log messages to a specified file.
+//!
+//! LoggerFile will write to a specified file, either appending to or overwriting that file at application startup.
 class LoggerFile : public Logger {
   public:
-	// Standard loggerFile, will write to a single log file.  File appending is configurable.
-	// ! If \a filePath is empty, uses the default ('cinder.log' next to app binary)
+	//! LoggerFile writes to a single log file.  File appending is configurable.
+	//! If \p filePath is empty, uses the default ('%cinder.log' next to app binary)
 	LoggerFile( const fs::path &filePath = fs::path(), bool appendToExisting = true );
-	// daily rotating logger, will write to a formatted log file, updated at the first log request
-	// after midnight.
-	// ! If \a folder or \a formatStr are empty, ignores request
-	LoggerFile( const fs::path &folder, const std::string &formatStr, bool appendToExisting = true );
+
 	virtual ~LoggerFile();
 
 	void write( const Metadata &meta, const std::string &text ) override;
 
+	//! Returns the file path targeted by this logger.
 	const fs::path&		getFilePath() const		{ return mFilePath; }
 
   protected:
@@ -185,15 +124,29 @@ class LoggerFile : public Logger {
 	void		ensureDirectoryExists();
 
 	fs::path		mFilePath;
-	fs::path		mFolderPath;
-	std::string		mDailyFormatStr;
-	int				mYearDay;
 	bool			mAppend;
-	bool			mRotating;
 	std::ofstream	mStream;
 };
 
-//! Logger that doesn't actually print anything, but triggers a breakpoint if a log event happens past a specified threshold
+//! LoggerFileRotating will write log messages to a file that is rotated at midnight.
+class LoggerFileRotating : public LoggerFile {
+public:
+	
+	//! Creates a rotating log file that will rotate when the first logging event occurs after midnight.
+	//! \p formatStr will be passed to strftime to determine the file name.
+	LoggerFileRotating( const fs::path &folder, const std::string &formatStr, bool appendToExisting = true );
+	
+	virtual ~LoggerFileRotating() { }
+	
+	void write( const Metadata &meta, const std::string &text ) override;
+	
+protected:
+	fs::path		mFolderPath;
+	std::string		mDailyFormatStr;
+	int				mYearDay;
+};
+	
+//! LoggerBreakpoint doesn't actually print anything, but triggers a breakpoint on log events above a specified threshold.
 class LoggerBreakpoint : public Logger {
   public:
 	LoggerBreakpoint( Level triggerLevel = LEVEL_ERROR )
@@ -204,17 +157,21 @@ class LoggerBreakpoint : public Logger {
 
 	void	setTriggerLevel( Level triggerLevel )	{ mTriggerLevel = triggerLevel; }
 	Level	getTriggerLevel() const					{ return mTriggerLevel; }
+	
   private:
 	Level	mTriggerLevel;
 };
 
-//! Provides 'system' logging support. Uses syslog on platforms that have it, on MSW uses Windows Event Logging. \note Does nothing on WinRT.
+//! LoggerSystem rovides 'system' logging support. Uses syslog on platforms that have it, on MSW uses Windows Event Logging.
+//! \note Does nothing on WinRT.
 class LoggerSystem : public Logger {
 public:
 	LoggerSystem();
 	virtual ~LoggerSystem();
 	
 	void write( const Metadata &meta, const std::string &text ) override;
+	//! Sets the minimum logging level that will trigger a system log.
+	//! \note Setting \p minLevel below CI_MIN_LOG_LEVEL is pointless; minLevel will act like CI_MIN_LOG_LEVEL.
 	void setLoggingLevel( Level minLevel ) { mMinLevel = minLevel; }
 	
 protected:
@@ -225,117 +182,56 @@ protected:
 #elif defined( CINDER_MSW )
 	class ImplEventLog;
 	std::unique_ptr<ImplEventLog> mImpl;
-#elif defined( CINDER_ANDROID )	
-	class ImplLogCat;
-	std::unique_ptr<ImplLogCat> mImpl;
-#elif defined( CINDER_LINUX )
-	class ImplConsole;
-	std::unique_ptr<ImplConsole> mImpl;
 #endif
 };
 
-//! \brief Logger that can log to multiple other Loggers.
+//! \brief LogManager manages a stack of all active Loggers.
 //!
-//! This is primarily used by LogManager as it's base Logger, when multiple log outputs are enabled (ex. console and file)
-class LoggerMulti : public Logger {
-  public:
-	void add( Logger *logger )							{ mLoggers.push_back( std::unique_ptr<Logger>( logger ) ); }
-	void add( std::unique_ptr<Logger> &&logger )		{ mLoggers.emplace_back( move( logger ) ); }
-
-	template <typename LoggerT>
-	LoggerT* findType();
-
-	void remove( Logger *logger );
-
-	const std::vector<std::unique_ptr<Logger> >& getLoggers() const	{ return mLoggers; }
-
-	void write( const Metadata &meta, const std::string &text ) override;
-
-  private:
-	std::vector<std::unique_ptr<Logger> >	mLoggers;
-};
-
+//! LogManager's default state contains a single LoggerConsole.  LogManager allows for adding and removing Loggers via their pointer values.
 class LogManager {
 public:
 	// Returns a pointer to the shared instance. To enable logging during shutdown, this instance is leaked at shutdown.
 	static LogManager* instance()	{ return sInstance; }
 	//! Destroys the shared instance. Useful to remove false positives with leak detectors like valgrind.
 	static void destroyInstance()	{ delete sInstance; }
-	//! Restores LogManager to its default state.
+	//! Restores LogManager to its default state - a single LoggerConsole.
 	void restoreToDefault();
 
-	//! Resets the current Logger stack so only \a logger exists.
-	void resetLogger( Logger *logger );
+	//! Removes all loggers from the stack.
+	void clearLoggers();
+	//! Resets the current Logger stack so only \p logger exists.
+	void resetLogger( const LoggerRef& logger );
 	//! Adds \a logger to the current stack of loggers.
-	void addLogger( Logger *logger );
+	void addLogger( const LoggerRef& logger );
 	//! Remove \a logger to the current stack of loggers.
-	void removeLogger( Logger *logger );
-	//! Returns a pointer to the current base Logger instance.
-	Logger* getLogger()	{ return mLogger.get(); }
-	//! Returns a logger of a specifc type, or nullptr is that type of Logger is currently not in use.
+	void removeLogger( const LoggerRef& logger );
+	//! Returns a vector of Loggers of a specifc type.
 	template<typename LoggerT>
-	LoggerT* getLogger();
-	//! Returns a vector of all current loggers
-	std::vector<Logger *> getAllLoggers();
-	//! Returns the mutex used for thread safe loggers. Also used when adding or resetting new loggers.
+	std::vector<std::shared_ptr<LoggerT>> getLoggers();
+	//! Returns a vector of LoggerRef that contains all active loggers
+	std::vector<LoggerRef> getAllLoggers();
+	//! Returns the mutex used for thread safe logging.
 	std::mutex& getMutex() const			{ return mMutex; }
-
-	void enableConsoleLogging();
-	void disableConsoleLogging();
-	void setConsoleLoggingEnabled( bool enable )		{ enable ? enableConsoleLogging() : disableConsoleLogging(); }
-	bool isConsoleLoggingEnabled() const				{ return mConsoleLoggingEnabled; }
-
-	void enableFileLogging( const fs::path &filePath = fs::path(), bool appendToExisting = true );
-	void enableFileLoggingRotating( const fs::path &folder, const std::string& formatStr, bool appendToExisting = true);
-	void disableFileLogging();
-	void setFileLoggingEnabled( bool enable, const fs::path &filePath = fs::path(), bool appendToExisting = true );
-	void setFileLoggingRotatingEnabled( bool enable, const fs::path &folder, const std::string &formatStr, bool appendToExisting = true );
-	bool isFileLoggingEnabled() const					{ return mFileLoggingEnabled; }
-
-	void enableSystemLogging();
-	void disableSystemLogging();
-	void setSystemLoggingEnabled( bool enable = true )		{ enable ? enableSystemLogging() : disableSystemLogging(); }
-	bool isSystemLoggingEnabled() const					{ return mSystemLoggingEnabled; }
-	void setSystemLoggingLevel( Level level );
-	Level getSystemLoggingLevel() const					{ return mSystemLoggingLevel; }
-
-	//! Enables a breakpoint to be triggered when a log message happens at `LEVEL_ERROR` or higher
-	void enableBreakOnError()							{ enableBreakOnLevel( LEVEL_ERROR ); }
-	//! Enables a breakpoint to be triggered when a log message happens at \a trigerLevel or higher.
-	void enableBreakOnLevel( Level trigerLevel );
-	//! Disables any breakpoints set for logging.
-	void disableBreakOnLog();
+	
+	void write( const Metadata &meta, const std::string &text );
+	
+	template<typename LoggerT, typename... Args>
+	std::shared_ptr<LoggerT> makeLogger( Args&&... args );
 
 protected:
 	LogManager();
 
-	bool initFileLogging();
-
-	std::unique_ptr<Logger>	mLogger;
-	LoggerMulti*			mLoggerMulti;
-	mutable std::mutex		mMutex;
-	bool					mConsoleLoggingEnabled, mFileLoggingEnabled, mSystemLoggingEnabled, mBreakOnLogEnabled;
-	Level					mSystemLoggingLevel;
-
-	static LogManager *sInstance;
+	std::vector<LoggerRef>			mLoggers;
+	
+	mutable std::mutex				mMutex;
+	
+	static LogManager 				*sInstance;
 };
-
-LogManager* manager();
-
+	
 struct Entry {
 	// TODO: move &&location
-	Entry( Level level, const Location &location )
-		: mHasContent( false )
-	{
-		mMetaData.mLevel = level;
-		mMetaData.mLocation = location;
-	}
-
-	~Entry()
-	{
-		if( mHasContent )
-			writeToLog();
-	}
+	Entry( Level level, const Location &location );
+	~Entry();
 
 	template <typename T>
 	Entry& operator<<( const T &rhs )
@@ -345,11 +241,7 @@ struct Entry {
 		return *this;
 	}
 
-	void writeToLog()
-	{
-		manager()->getLogger()->write( mMetaData, mStream.str() );
-	}
-
+	void writeToLog();
 	const Metadata&	getMetaData() const	{ return mMetaData; }
 
 private:
@@ -359,52 +251,48 @@ private:
 	std::stringstream	mStream;
 };
 
+// ----------------------------------------------------------------------------------
+// Freestanding functions
 
-template<class LoggerT>
-class ThreadSafeT : public LoggerT {
-  public:
-	template <typename... Args>
-	ThreadSafeT( Args &&... args )
-	: LoggerT( std::forward<Args>( args )... )
-	{}
+//! The global manager for logging, used to manipulate the Logger stack. Provides thread safety amongst the Loggers.
+LogManager* manager();
 
-	void write( const Metadata &meta, const std::string &text ) override
-	{
-		std::lock_guard<std::mutex> lock( manager()->getMutex() );
-		LoggerT::write( meta, text );
-	}
-};
-
-typedef ThreadSafeT<LoggerConsole>		LoggerConsoleThreadSafe;
-typedef ThreadSafeT<LoggerFile>			LoggerFileThreadSafe;
+//! Creates and returns a new logger of type LoggerT, adding it to the current Logger stack.
+template<typename LoggerT, typename... Args>
+std::shared_ptr<LoggerT> makeLogger( Args&&... args )
+{
+	return manager()->makeLogger<LoggerT>( std::forward<Args>( args )... );
+}
 
 // ----------------------------------------------------------------------------------
 // Template method implementations
 
-template <typename LoggerT>
-LoggerT* LoggerMulti::findType()
+template<typename LoggerT, typename... Args>
+std::shared_ptr<LoggerT> LogManager::makeLogger( Args&&... args )
 {
-	for( const auto &logger : mLoggers ) {
-		auto result = dynamic_cast<LoggerT *>( logger.get() );
-		if( result )
-			return result;
-	}
-
-	return nullptr;
+	static_assert( std::is_base_of<Logger, LoggerT>::value, "LoggerT must inherit from log::Logger" );
+	
+	std::shared_ptr<LoggerT> result = std::make_shared<LoggerT>( std::forward<Args>( args )... );
+	addLogger( result );
+	return result;
 }
 
 template<typename LoggerT>
-LoggerT* LogManager::getLogger()
+std::vector<std::shared_ptr<LoggerT>> LogManager::getLoggers()
 {
-	auto loggerMulti = dynamic_cast<LoggerMulti *>( mLogger.get() );
-	if( loggerMulti ) {
-		return loggerMulti->findType<LoggerT>();
-	}
-	else {
-		return dynamic_cast<LoggerT *>( mLogger.get() );
-	}
-}
+	std::vector<std::shared_ptr<LoggerT>> result;
 
+	std::lock_guard<std::mutex> lock( manager()->getMutex() );
+	for( const auto &logger : mLoggers ) {
+		auto loggerCasted = std::dynamic_pointer_cast<LoggerT>( logger );
+		if( loggerCasted ) {
+			result.push_back( loggerCasted );
+		}
+	}
+
+	return result;
+}
+	
 } } // namespace cinder::log
 
 // ----------------------------------------------------------------------------------

--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -43,17 +43,6 @@
 #include <mutex>
 #include <time.h>
 
-#if defined( CINDER_ANDROID )
-	#include <android/log.h>
-	#include <sstream> 
- 	#define TAG "cinder"
-#endif 
-
-#define DEFAULT_FILE_LOG_PATH "cinder.log"
-
-// TODO: consider storing Logger's as shared_ptr instead
-//	- they really aren't shared, but makes swapping them in and out and LogManager's handles easier
-
 using namespace std;
 
 namespace cinder { namespace log {
@@ -109,207 +98,77 @@ LogManager::LogManager()
 	restoreToDefault();
 }
 
-void LogManager::resetLogger( Logger *logger )
+void LogManager::clearLoggers()
 {
 	lock_guard<mutex> lock( mMutex );
-
-	mLogger.reset( logger );
-
-	LoggerMulti *multi = dynamic_cast<LoggerMulti *>( logger );
-	mLoggerMulti = multi ? multi : nullptr;
-
-	mConsoleLoggingEnabled = mFileLoggingEnabled = mSystemLoggingEnabled = false;
+	mLoggers.clear();
 }
-
-void LogManager::addLogger( Logger *logger )
+	
+void LogManager::resetLogger( const LoggerRef& logger )
 {
 	lock_guard<mutex> lock( mMutex );
-
-	if( ! mLoggerMulti ) {
-		auto loggerMulti = unique_ptr<LoggerMulti>( new LoggerMulti );
-		loggerMulti->add( move( mLogger ) );
-		mLoggerMulti = loggerMulti.get();
-		mLogger = move( loggerMulti );
-	}
-
-	mLoggerMulti->add( logger );
+	mLoggers.clear();
+	mLoggers.push_back( logger );
 }
 
-
-void LogManager::removeLogger( Logger *logger )
+void LogManager::addLogger( const LoggerRef& logger )
 {
-	CI_ASSERT( mLoggerMulti );
-
-	mLoggerMulti->remove( logger );
+	lock_guard<mutex> lock( mMutex );
+	mLoggers.push_back( logger );
 }
 
+void LogManager::removeLogger( const LoggerRef& logger )
+{
+	lock_guard<mutex> lock( mMutex );
+	mLoggers.erase( remove_if( mLoggers.begin(), mLoggers.end(),
+							  [logger]( const LoggerRef &o ) {
+								  return o == logger;
+							  } ),
+				   mLoggers.end() );
+}
+
+std::vector<LoggerRef> LogManager::getAllLoggers()
+{
+	lock_guard<mutex> lock( mMutex );
+	return mLoggers;
+}
+	
 void LogManager::restoreToDefault()
 {
+	clearLoggers();
+	makeLogger<LoggerConsole>();
+}
+	
+void LogManager::write( const Metadata &meta, const std::string &text )
+{
+	// TODO move this to a shared_lock_timed with c++14 support
 	lock_guard<mutex> lock( mMutex );
 
-	mLogger.reset( new LoggerConsoleThreadSafe );
-	mLoggerMulti = nullptr;
-	mConsoleLoggingEnabled = true;
-	mFileLoggingEnabled = false;
-	mSystemLoggingEnabled = false;
-	mBreakOnLogEnabled = false;
-
-	switch( CI_MIN_LOG_LEVEL ) {
-		case 5: mSystemLoggingLevel = LEVEL_FATAL;      break;
-		case 4: mSystemLoggingLevel = LEVEL_ERROR;      break;
-		case 3: mSystemLoggingLevel = LEVEL_WARNING;	break;
-		case 2: mSystemLoggingLevel = LEVEL_INFO;       break;
-		case 1: mSystemLoggingLevel = LEVEL_DEBUG;		break;
-		case 0: mSystemLoggingLevel = LEVEL_VERBOSE;	break;
-		default: CI_ASSERT_NOT_REACHABLE();
+	for( auto& logger : mLoggers ) {
+		logger->write( meta, text );
 	}
 }
 
-vector<Logger *> LogManager::getAllLoggers()
+// ----------------------------------------------------------------------------------------------------
+// MARK: - Entry
+// ----------------------------------------------------------------------------------------------------
+
+Entry::Entry( Level level, const Location &location )
+: mHasContent( false )
 {
-	vector<Logger *> result;
-
-	if( mLoggerMulti ) {
-		for( const auto &logger : mLoggerMulti->getLoggers() )
-			result.push_back( logger.get() );
-	}
-	else
-		result.push_back( mLogger.get() );
-
-	return result;
+	mMetaData.mLevel = level;
+	mMetaData.mLocation = location;
 }
 
-void LogManager::enableConsoleLogging()
+Entry::~Entry()
 {
-	if( mConsoleLoggingEnabled )
-		return;
-
-	addLogger( new LoggerConsoleThreadSafe );
-	mConsoleLoggingEnabled = true;
+	if( mHasContent )
+		writeToLog();
 }
 
-bool LogManager::initFileLogging()
+void Entry::writeToLog()
 {
-	if( mFileLoggingEnabled ) {
-		// destroys previous file logger to prepare for changes
-		auto logger = mLoggerMulti->findType<LoggerFile>();
-		if( logger )
-			disableFileLogging();
-		else
-			return false;
-	}
-	return true;
-}
-
-void LogManager::enableFileLogging( const fs::path &path, bool appendToExisting )
-{
-	if( ! initFileLogging() ) {
-		return;
-	}
-
-	addLogger( new LoggerFileThreadSafe( path, appendToExisting ) );
-	mFileLoggingEnabled = true;
-}
-
-void LogManager::enableFileLoggingRotating( const fs::path &folder, const std::string &formatStr, bool appendToExisting )
-{
-	if( ! initFileLogging() ) {
-		return;
-	}
-
-	addLogger( new LoggerFileThreadSafe( folder, formatStr, appendToExisting ) );
-	mFileLoggingEnabled = true;
-}
-
-void LogManager::setFileLoggingEnabled( bool enable, const fs::path &filePath, bool appendToExisting )
-{
-	if( enable )
-		enableFileLogging( filePath, appendToExisting );
-	else
-		disableFileLogging();
-}
-
-
-void LogManager::setFileLoggingRotatingEnabled( bool enable, const fs::path &folder, const string &formatStr, bool appendToExisting )
-{
-	if( enable )
-		enableFileLoggingRotating( folder, formatStr, appendToExisting );
-	else
-		disableFileLogging();
-}
-
-void LogManager::enableSystemLogging()
-{
-	if( mSystemLoggingEnabled )
-		return;
-
-	addLogger( new LoggerSystem );
-	setSystemLoggingLevel( mSystemLoggingLevel );
-	mSystemLoggingEnabled = true;
-}
-
-void LogManager::setSystemLoggingLevel( Level level )
-{
-	mSystemLoggingLevel = level;
-	
-	auto logger = mLoggerMulti->findType<LoggerSystem>();
-	logger->setLoggingLevel( level );
-}
-
-void LogManager::disableConsoleLogging()
-{
-	if( ! mConsoleLoggingEnabled || ! mLoggerMulti )
-		return;
-
-	auto logger = mLoggerMulti->findType<LoggerConsole>();
-	mLoggerMulti->remove( logger );
-
-	mConsoleLoggingEnabled = false;
-}
-
-void LogManager::disableFileLogging()
-{
-	if( ! mFileLoggingEnabled || ! mLoggerMulti )
-		return;
-
-	auto logger = mLoggerMulti->findType<LoggerFile>();
-	mLoggerMulti->remove( logger );
-
-	mFileLoggingEnabled = false;
-}
-
-void LogManager::disableSystemLogging()
-{
-	if( ! mSystemLoggingEnabled || ! mLoggerMulti )
-		return;
-
-	auto logger = mLoggerMulti->findType<LoggerSystem>();
-	mLoggerMulti->remove( logger );
-	mSystemLoggingEnabled = false;
-}
-
-void LogManager::enableBreakOnLevel( Level triggerLevel )
-{
-	if( mBreakOnLogEnabled ) {
-		auto logger = mLoggerMulti->findType<LoggerBreakpoint>();
-		logger->setTriggerLevel( triggerLevel );
-	}
-	else {
-		addLogger( new LoggerBreakpoint( triggerLevel ) );
-		mBreakOnLogEnabled = true;
-	}
-}
-
-void LogManager::disableBreakOnLog()
-{
-	if( ! mBreakOnLogEnabled )
-		return;
-	
-	auto logger = mLoggerMulti->findType<LoggerBreakpoint>();
-	if( logger )
-		mLoggerMulti->remove( logger );
-
-	mBreakOnLogEnabled = false;
+	manager()->write( mMetaData, mStream.str() );
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -318,45 +177,12 @@ void LogManager::disableBreakOnLog()
 
 void Logger::writeDefault( std::ostream &stream, const Metadata &meta, const std::string &text )
 {
-#if defined( CINDER_ANDROID )
-	if( OUTPUT_CONSOLE == getOutput() ) {
-		std::stringstream ss;
-
-		ss << meta.mLevel << " ";
-
-		if( isTimestampEnabled() )
-			ss << getCurrentDateTimeString() << " ";
-
-		ss << meta.mLocation << " " << text;
-
-		android_LogPriority prio = ANDROID_LOG_DEFAULT;
-		switch( meta.mLevel ) {
-			case LEVEL_VERBOSE:	prio = ANDROID_LOG_VERBOSE; break;
-			case LEVEL_INFO:	prio = ANDROID_LOG_INFO; 	break;
-			case LEVEL_DEBUG:	prio = ANDROID_LOG_DEBUG; 	break;
-			case LEVEL_WARNING:	prio = ANDROID_LOG_WARN; 	break;
-			case LEVEL_ERROR:	prio = ANDROID_LOG_ERROR; 	break;
-			case LEVEL_FATAL:	prio = ANDROID_LOG_FATAL; 	break;
-		}
-
-		__android_log_print( prio, TAG, ss.str().c_str() );
-	}
-	else {
-		stream << meta.mLevel << " ";
-
-		if( isTimestampEnabled() )
-			stream << getCurrentDateTimeString() << " ";
-
-		stream << meta.mLocation << " " << text << endl;		
-	}
-#else	
 	stream << meta.mLevel << " ";
 
 	if( isTimestampEnabled() )
 		stream << getCurrentDateTimeString() << " ";
 
 	stream << meta.mLocation << " " << text << endl;
-#endif	
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -369,48 +195,15 @@ void LoggerConsole::write( const Metadata &meta, const string &text )
 }
 
 // ----------------------------------------------------------------------------------------------------
-// MARK: - LoggerMulti
-// ----------------------------------------------------------------------------------------------------
-
-void LoggerMulti::remove( Logger *logger )
-{
-	mLoggers.erase( remove_if( mLoggers.begin(), mLoggers.end(),
-							  [logger]( const std::unique_ptr<Logger> &o ) {
-								  return o.get() == logger;
-							  } ),
-				   mLoggers.end() );
-}
-
-void LoggerMulti::write( const Metadata &meta, const string &text )
-{
-	for( auto &logger : mLoggers )
-		logger->write( meta, text );
-}
-
-// ----------------------------------------------------------------------------------------------------
 // MARK: - LoggerFile
 // ----------------------------------------------------------------------------------------------------
 
 LoggerFile::LoggerFile( const fs::path &filePath, bool appendToExisting )
-	: mFilePath( filePath ), mAppend( appendToExisting ), mRotating( false )
+: mFilePath( filePath ), mAppend( appendToExisting )
 {
 	if( mFilePath.empty() )
 		mFilePath = getDefaultLogFilePath();
-
-	setTimestampEnabled();
-}
-
-LoggerFile::LoggerFile( const fs::path &folder, const std::string &formatStr, bool appendToExisting )
-	: mFolderPath( folder ), mDailyFormatStr( formatStr ), mAppend( appendToExisting ), mRotating( true )
-{
-	CI_ASSERT_MSG( ! formatStr.empty(), "cannot provide empty formatStr" );
 	
-	if( mFolderPath.empty() )
-		mFolderPath = getDefaultLogFilePath().parent_path();
-
-	mYearDay = getCurrentYearDay();
-	mFilePath = mFolderPath / fs::path( getDailyLogString( mDailyFormatStr ) );
-
 	setTimestampEnabled();
 }
 
@@ -422,14 +215,6 @@ LoggerFile::~LoggerFile()
 
 void LoggerFile::write( const Metadata &meta, const string &text )
 {
-	if( mRotating && mYearDay != getCurrentYearDay() ) {
-		mFilePath = mFolderPath / fs::path( getDailyLogString( mDailyFormatStr ) );
-		mYearDay = getCurrentYearDay();
-
-		if( mStream.is_open() )
-			mStream.close();
-	}
-
 	if( ! mStream.is_open() ) {
 		ensureDirectoryExists();
 		mAppend ? mStream.open( mFilePath.string(), std::ofstream::app ) : mStream.open( mFilePath.string() );
@@ -457,6 +242,42 @@ void LoggerFile::ensureDirectoryExists()
 			cerr << "ci::log::LoggerFile error: Unable to create folder \"" << dir.string() << "\"" << endl;
 		}
 	}
+}
+
+// ----------------------------------------------------------------------------------------------------
+// MARK: - LoggerFileRotating
+// ----------------------------------------------------------------------------------------------------
+
+LoggerFileRotating::LoggerFileRotating( const fs::path &folder, const std::string &formatStr, bool appendToExisting )
+: mFolderPath( folder ), mDailyFormatStr( formatStr )
+{
+	CI_ASSERT_MSG( ! formatStr.empty(), "cannot provide empty formatStr" );
+	if( formatStr.empty() ) {
+		return;
+	}
+	
+	if( mFolderPath.empty() ) {
+		mFolderPath = getDefaultLogFilePath().parent_path();
+	}
+	
+	mAppend = appendToExisting;
+	mYearDay = getCurrentYearDay();
+	mFilePath = mFolderPath / fs::path( getDailyLogString( mDailyFormatStr ) );
+	
+	setTimestampEnabled();
+}
+
+void LoggerFileRotating::write( const Metadata &meta, const string &text )
+{
+	if( mYearDay != getCurrentYearDay() ) {
+		mFilePath = mFolderPath / fs::path( getDailyLogString( mDailyFormatStr ) );
+		mYearDay = getCurrentYearDay();
+		
+		if( mStream.is_open() )
+			mStream.close();
+	}
+	
+	LoggerFile::write( meta, text );
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -593,51 +414,6 @@ protected:
 	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> mConverter;
 };
 
-#elif defined( CINDER_ANDROID )
-
-// ----------------------------------------------------------------------------------------------------
-// MARK: - ImplLogCat
-// ----------------------------------------------------------------------------------------------------
-
-class LoggerSystem::ImplLogCat : public Logger {
-public:
-	ImplLogCat()
-	{
-	}
-	
-	virtual ~ImplLogCat()
-	{
-	}
-	
-	void write( const Metadata &meta, const std::string &text ) override
-	{
-		std::stringstream dummyStream;
-		writeDefault( dummyStream, meta, text );
-	};	
-};
-	
-#elif defined( CINDER_LINUX )
-
-// ----------------------------------------------------------------------------------------------------
-// MARK: - ImplConsole
-// ----------------------------------------------------------------------------------------------------
-
-class LoggerSystem::ImplConsole : public Logger {
-public:
-	ImplConsole()
-	{
-	}
-	
-	virtual ~ImplConsole()
-	{
-	}
-	
-	void write( const Metadata &meta, const std::string &text ) override
-	{
-		writeDefault( std::cout, meta, text );
-	}	
-};
-
 #endif
 
 	
@@ -647,7 +423,7 @@ public:
 
 LoggerSystem::LoggerSystem()
 {
-	mMinLevel = LEVEL_VERBOSE;
+	mMinLevel = static_cast<Level>(CI_MIN_LOG_LEVEL);
 #if defined( CINDER_COCOA )
 	LoggerSystem::mImpl = std::unique_ptr<ImplSysLog>( new ImplSysLog() );
 #elif defined( CINDER_MSW )
@@ -690,7 +466,7 @@ ostream& operator<<( ostream &lhs, const Level &rhs )
 	switch( rhs ) {
 		case LEVEL_VERBOSE:		lhs << "|verbose|";	break;
 		case LEVEL_DEBUG:		lhs << "|debug  |";	break;
-		case LEVEL_INFO:		lhs << "|info   |";	break;	
+		case LEVEL_INFO:		lhs << "|info   |";	break;
 		case LEVEL_WARNING:		lhs << "|warning|";	break;
 		case LEVEL_ERROR:		lhs << "|error  |";	break;
 		case LEVEL_FATAL:		lhs << "|fatal  |";	break;


### PR DESCRIPTION
First, this gets android version in sync with master branch, which recently got a nice overhaul from @lucasvickers (see #1127 in main repo).

I also moved the logcat stuff to `LoggerSystem::ImplLogCat`, and we just use this by default instead of `LoggerConsole`.  As such, we can do away with the Output enum.

In this version, the different log levels will route to levels for logcat too, I'm not exactly sure why they were all going to Info before but now the following code:

```cpp
	CI_LOG_I( "bang" );
	CI_LOG_V( "bang" );
	CI_LOG_D( "bang" );
	CI_LOG_W( "bang" );
	CI_LOG_E( "bang" );
```

prints to logcat:

```
10-22 02:20:26.813  12245-12273/org.libcinder.samples.bufferplayer I/cinder﹕ |info   | virtual void BufferPlayerNodeApp::setup()[34] bang
10-22 02:20:26.813  12245-12273/org.libcinder.samples.bufferplayer V/cinder﹕ |verbose| virtual void BufferPlayerNodeApp::setup()[35] bang
10-22 02:20:26.813  12245-12273/org.libcinder.samples.bufferplayer D/cinder﹕ |debug  | virtual void BufferPlayerNodeApp::setup()[36] bang
10-22 02:20:26.813  12245-12273/org.libcinder.samples.bufferplayer W/cinder﹕ |warning| virtual void BufferPlayerNodeApp::setup()[37] bang
10-22 02:20:26.813  12245-12273/org.libcinder.samples.bufferplayer E/cinder﹕ |error  | virtual void BufferPlayerNodeApp::setup()[38] bang
```

And last one is red. :)