### PR TITLE
Add Base64.cpp to the android build. Force char to be signed

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -486,9 +486,9 @@ endif()
 
 # C_FLAGS
 if( NDK_TOOLCHAIN_CLANG )
-    set( C_FLAGS "-DANDROID -DFT2_BUILD_LIBRARY ${ARCH_FLAGS} -fvisibility=default" )
+    set( C_FLAGS "-DANDROID -DFT2_BUILD_LIBRARY ${ARCH_FLAGS} -fvisibility=default -fsigned-char" )
 else()
-    set( C_FLAGS "-DFT2_BUILD_LIBRARY ${ARCH_FLAGS} -fvisibility=default" )
+    set( C_FLAGS "-DFT2_BUILD_LIBRARY ${ARCH_FLAGS} -fvisibility=default -fsigned-char" )
 endif()
 if( NDK_GLES2 )
     set( C_FLAGS "-DCINDER_GL_ES_2 ${C_FLAGS}")
@@ -506,7 +506,7 @@ if( NDK_TOOLCHAIN_CLANG )
 		${NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/4.9/libs/${NDK_ARCH}/include
 	)
 else()
-    set( CXX_FLAGS "${ARCH_FLAGS} -fvisibility=default -std=c++11 -DFT2_BUILD_LIBRARY" )
+    set( CXX_FLAGS "${ARCH_FLAGS} -fvisibility=default -std=c++11 -fsigned-char -DFT2_BUILD_LIBRARY" )
 endif()
 if( NDK_GLES2 )
     set( CXX_FLAGS "-DCINDER_GL_ES_2 ${CXX_FLAGS}")
@@ -639,6 +639,7 @@ set( CINDER_CXX_SRC_FILES
     ${CINDER_SRC_DIR}/cinder/svg/Svg.cpp
 
     ${CINDER_SRC_DIR}/cinder/Area.cpp
+    ${CINDER_SRC_DIR}/cinder/Base64.cpp
     ${CINDER_SRC_DIR}/cinder/BSpline.cpp
     ${CINDER_SRC_DIR}/cinder/BSplineFit.cpp
     ${CINDER_SRC_DIR}/cinder/Buffer.cpp

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -500,13 +500,13 @@ set( CMAKE_C_FLAGS_RELEASE "${C_FLAGS} -Os -ffast-math ${C_FLAGS}" )
 
 # CXX_FLAGS
 if( NDK_TOOLCHAIN_CLANG )
-    set( CXX_FLAGS "-gcc-toolchain ${NDK_ROOT}/toolchains/arm-linux-androideabi-4.9/prebuilt/${NDK_TOOLCHAIN_HOST} ${ARCH_FLAGS} -fvisibility=default -std=c++11 -stdlib=libstdc++ -ffunction-sections -funwind-tables -Wno-invalid-command-line-argument -Wno-unused-command-line-argument -no-canonical-prefixes -fomit-frame-pointer -DANDROID -DFT2_BUILD_LIBRARY" )
+    set( CXX_FLAGS "-gcc-toolchain ${NDK_ROOT}/toolchains/arm-linux-androideabi-4.9/prebuilt/${NDK_TOOLCHAIN_HOST} ${ARCH_FLAGS} -fvisibility=default -fsigned-char -std=c++11 -stdlib=libstdc++ -ffunction-sections -funwind-tables -Wno-invalid-command-line-argument -Wno-unused-command-line-argument -no-canonical-prefixes -fomit-frame-pointer -DANDROID -DFT2_BUILD_LIBRARY" )
 	include_directories(
 		${NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/4.9/include
 		${NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/4.9/libs/${NDK_ARCH}/include
 	)
 else()
-    set( CXX_FLAGS "${ARCH_FLAGS} -fvisibility=default -std=c++11 -fsigned-char -DFT2_BUILD_LIBRARY" )
+    set( CXX_FLAGS "${ARCH_FLAGS} -fvisibility=default -fsigned-char -std=c++11 -DFT2_BUILD_LIBRARY" )
 endif()
 if( NDK_GLES2 )
     set( CXX_FLAGS "-DCINDER_GL_ES_2 ${CXX_FLAGS}")


### PR DESCRIPTION
Base64.cpp was missing from Android. Also turns out `char` is unsigned by default on ARM, which was causing GCC to rightly warn about narrowing.